### PR TITLE
feat: Implement shimmer effect for warehouse loading

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,10 @@ dependencies {
     //coil
     implementation ("io.coil-kt:coil-compose:2.6.0")
 
+    //shimmer effect
+    implementation ("com.google.accompanist:accompanist-placeholder-material3:0.34.0")
+
+
     //koin
     val koin_android_version = "4.0.2"
     implementation("io.insert-koin:koin-android:$koin_android_version")

--- a/app/src/main/java/com/example/atonce/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/atonce/di/NetworkModule.kt
@@ -7,7 +7,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 val networkModule = module {
     single {
         Retrofit.Builder()
-            .baseUrl("http://predeploypharmaatonce.somee.com/")
+            .baseUrl("http://predeploypharmaatonceafteredit.somee.com/")
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/com/example/atonce/domain/entity/Warehouse.kt
+++ b/app/src/main/java/com/example/atonce/domain/entity/Warehouse.kt
@@ -1,6 +1,5 @@
 package com.example.atonce.domain.entity
 
-import androidx.compose.ui.graphics.vector.ImageVector
 
 data class Warehouse(
     val id: Int,
@@ -11,3 +10,4 @@ data class Warehouse(
     val imageUrl : String,
     val deliveryRate : String,
 )
+

--- a/app/src/main/java/com/example/atonce/domain/usecase/dummy.kt
+++ b/app/src/main/java/com/example/atonce/domain/usecase/dummy.kt
@@ -1,4 +1,0 @@
-package com.example.atonce.domain.usecase
-
-class dummy {
-}

--- a/app/src/main/java/com/example/atonce/presentation/home/view/HomeScreen.kt
+++ b/app/src/main/java/com/example/atonce/presentation/home/view/HomeScreen.kt
@@ -29,6 +29,7 @@ import com.example.atonce.presentation.common.component.app_bar_cards.TowIconCar
 import com.example.atonce.presentation.home.view.component.AdPager
 import com.example.atonce.presentation.home.view.component.WarehouseCard
 import com.example.atonce.presentation.common.theme.SemiBoldFont
+import com.example.atonce.presentation.home.view.component.ShimmerWarehouseCard
 import com.example.atonce.presentation.home.viewmodel.HomeViewModel
 import org.koin.androidx.compose.koinViewModel
 
@@ -108,7 +109,7 @@ fun HomeScreen(onProfileClick: () -> Unit,onNavToStore: () -> Unit, modifier: Pa
 
         when (val state = uiState.value) {
             is Response.Loading -> {
-                item { ProgressIndicator() }
+                items(5) { ShimmerWarehouseCard() }
             }
             is Response.Success -> {
                 val warehouses = state.data

--- a/app/src/main/java/com/example/atonce/presentation/home/view/component/ShimmerWarehouseCard.kt
+++ b/app/src/main/java/com/example/atonce/presentation/home/view/component/ShimmerWarehouseCard.kt
@@ -1,0 +1,112 @@
+package com.example.atonce.presentation.home.view.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.placeholder.PlaceholderHighlight
+import com.google.accompanist.placeholder.material3.placeholder
+import com.google.accompanist.placeholder.material3.shimmer
+
+@Composable
+fun ShimmerWarehouseCard() {
+    val colors = MaterialTheme.colorScheme
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        colors = CardDefaults.cardColors(containerColor = colors.surface)
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .placeholder(
+                        visible = true,
+                        highlight = PlaceholderHighlight.shimmer(),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "",
+                    modifier = Modifier
+                        .fillMaxWidth(0.6f)
+                        .height(16.dp)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "",
+                    modifier = Modifier
+                        .fillMaxWidth(0.4f)
+                        .height(12.dp)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "",
+                    modifier = Modifier
+                        .fillMaxWidth(0.5f)
+                        .height(14.dp)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "",
+                    modifier = Modifier
+                        .fillMaxWidth(0.3f)
+                        .height(12.dp)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/atonce/presentation/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/atonce/presentation/home/viewmodel/HomeViewModel.kt
@@ -49,10 +49,4 @@ class HomeViewModel(private val getWarehousesByAreaUseCase: GetAllWarehousesByAr
             }
         }
     }
-
-    fun resetPagination() {
-        currentPage = 1
-        isLastPage = false
-        _uiState.value = Response.Loading
-    }
 }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">predeploypharmaatonce.somee.com</domain>
+        <domain includeSubdomains="true">predeploypharmaatonceafteredit.somee.com</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
This commit introduces a shimmer effect to enhance the user experience while warehouse data is being fetched.

Key changes:
- Added `ShimmerWarehouseCard.kt` which displays a placeholder card with a shimmer animation.
- Updated `HomeScreen.kt` to show a list of `ShimmerWarehouseCard` components when the UI state is `Response.Loading`.
- Added `com.google.accompanist:accompanist-placeholder-material3` dependency for the shimmer effect.
- Updated the base URL in `NetworkModule.kt` to `http://predeploypharmaatonceafteredit.somee.com/`.
- Updated the domain in `network_security_config.xml` to `predeploypharmaatonceafteredit.somee.com`.
- Removed unused `dummy.kt` file.
- Removed unused `resetPagination` function from `HomeViewModel.kt`.
- Removed unused `ImageVector` import from `Warehouse.kt`.