### PR TITLE
feat: Implement add to cart functionality in StoreScreen

### DIFF
--- a/app/src/main/java/com/example/atonce/data/mappers/WarehouseMedicineMapper.kt
+++ b/app/src/main/java/com/example/atonce/data/mappers/WarehouseMedicineMapper.kt
@@ -5,6 +5,7 @@ import com.example.atonce.presentation.store.model.WarehouseMedicines
 
 fun WarehouseMedicinesItemDto.toEntity(): WarehouseMedicines {
     return WarehouseMedicines(
+        medicineId = medicineId,
         arabicMedicineName = arabicMedicineName,
         type = drug,
         englishMedicineName =englishMedicineName,

--- a/app/src/main/java/com/example/atonce/di/ViewModelModule.kt
+++ b/app/src/main/java/com/example/atonce/di/ViewModelModule.kt
@@ -15,7 +15,7 @@ val viewModelModule = module {
     viewModel { HomeViewModel(get(), get()) }
     viewModel { LoginViewModel(get(), get()) }
     viewModel { LoginViewModel(get(),get()) }
-    viewModel { WarehouseViewModel(get()) }
+    viewModel { WarehouseViewModel(get(), get(), get()) }
     viewModel { SignUpViewModel(get(),get() , get()) }
     viewModel { SearchViewModel(get() , get(), get(), get(), get()) }
     viewModel { ProfileViewModel(get(),get(),get()) }

--- a/app/src/main/java/com/example/atonce/presentation/common/navigation/NavHost.kt
+++ b/app/src/main/java/com/example/atonce/presentation/common/navigation/NavHost.kt
@@ -102,6 +102,7 @@ fun SetUpNavHost(
             val warehouseId = it.toRoute<ScreenRoute.StoreScreen>().warehouseId
             StoreScreen(
                 warehouseId = warehouseId,
+                snackbarHostState = snackbarState,
                 modifier =paddingValues,
                 onBackClick = {
                     navController.popBackStack()

--- a/app/src/main/java/com/example/atonce/presentation/search/view/SearchScreen.kt
+++ b/app/src/main/java/com/example/atonce/presentation/search/view/SearchScreen.kt
@@ -40,7 +40,11 @@ import org.koin.androidx.compose.koinViewModel
 
 @ExperimentalMaterial3Api
 @Composable
-fun SearchScreen(modifier: PaddingValues, snackbarHostState: SnackbarHostState, viewModel: SearchViewModel = koinViewModel()) {
+fun SearchScreen(
+    modifier: PaddingValues,
+    snackbarHostState: SnackbarHostState,
+    viewModel: SearchViewModel = koinViewModel())
+{
     var showBottomSheet by remember { mutableStateOf(false) }
     val expanded = remember { mutableStateOf(false) }
     var searchText by remember { mutableStateOf("") }
@@ -58,7 +62,7 @@ fun SearchScreen(modifier: PaddingValues, snackbarHostState: SnackbarHostState, 
     val isLoading by viewModel.loadingItemId.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.getMedicinesByArea(3, search = "")
+        viewModel.getMedicinesByArea(areaId, search = "")
         viewModel.message.collect { message ->
             snackbarHostState.showSnackbar(message)
         }
@@ -69,7 +73,7 @@ fun SearchScreen(modifier: PaddingValues, snackbarHostState: SnackbarHostState, 
             .collect { lastVisible ->
                 val totalItems = listState.layoutInfo.totalItemsCount
                 if (lastVisible == totalItems - 1) {
-                    viewModel.getMedicinesByArea(areaId = 3, search = viewModel.searchQuery.value)
+                    viewModel.getMedicinesByArea(areaId = areaId, search = viewModel.searchQuery.value)
                 }
             }
     }

--- a/app/src/main/java/com/example/atonce/presentation/store/model/WarehouseMedicines.kt
+++ b/app/src/main/java/com/example/atonce/presentation/store/model/WarehouseMedicines.kt
@@ -1,6 +1,7 @@
 package com.example.atonce.presentation.store.model
 
 data class WarehouseMedicines(
+    val medicineId: Int,
     val arabicMedicineName: String,
     val type: Int,
     val englishMedicineName: String,

--- a/app/src/main/java/com/example/atonce/presentation/store/view/component/MedicineCard.kt
+++ b/app/src/main/java/com/example/atonce/presentation/store/view/component/MedicineCard.kt
@@ -40,7 +40,11 @@ import java.util.Locale
 
 
 @Composable
-fun MedicineCard(obj: WarehouseMedicines){
+fun MedicineCard(
+    obj: WarehouseMedicines,
+    onClick: () -> Unit = {},
+    enabled: Boolean = true
+){
     val configuration = LocalConfiguration.current
     val screenWidth = configuration.screenWidthDp
     val screenHeight = configuration.screenHeightDp
@@ -111,8 +115,14 @@ fun MedicineCard(obj: WarehouseMedicines){
                     textDecoration = TextDecoration.LineThrough
                 )
 
-                Spacer(Modifier.weight(1f))            }
-            CustomCartBtn()
+                Spacer(Modifier.weight(1f))
+            }
+            CustomCartBtn(
+                onClick = {
+                    onClick()
+                },
+                enabled = enabled
+            )
 
         }
     }


### PR DESCRIPTION
This commit introduces the ability to add medicines to the cart from the `StoreScreen`.

Key changes:

- **StoreScreen:**
    - Passed `SnackbarHostState` to display messages.
    - Updated `MedicineCard` to include an `onClick` handler for adding items to the cart and an `enabled` state to prevent multiple clicks while processing.
    - `addToCart` function in `WarehouseViewModel` is called when the cart button on `MedicineCard` is clicked.
    - Now uses the `warehouseId` passed via navigation for fetching medicines.
- **WarehouseViewModel:**
    - Added `AddToCartUseCase` and `GetPharmacyUseCase` dependencies.
    - Implemented `addToCart` function to call the use case and emit messages via `_message` SharedFlow.
    - Added `_loadingItemId` StateFlow to track which item is currently being added to the cart, disabling its button.
- **MedicineCard:**
    - Added `onClick` lambda parameter.
    - Added `enabled` parameter to control the cart button's state.
- **WarehouseMedicines (Model):**
    - Added `medicineId` field.
- **WarehouseMedicineMapper:**
    - Updated to map `medicineId` from DTO to entity.
- **SearchScreen:**
    - Corrected `areaId` usage in `getMedicinesByArea` calls.
- **ViewModelModule:**
    - Updated `WarehouseViewModel` factory to include new dependencies.
- **NavHost:**
    - Passed `snackbarHostState` to `StoreScreen`.